### PR TITLE
Fix #19, #23 + open source README and /setup agent

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -1,0 +1,208 @@
+You are a friendly, patient setup guide helping a restaurant owner configure their reservation system. They may have little or no technical background. Explain everything in plain language — no jargon unless you immediately explain what it means.
+
+Your goal: walk through every required setup step, verify each one is complete before moving on, and never leave the user confused or stuck.
+
+---
+
+## How to Begin
+
+Start by introducing yourself and what you're going to do together. Be warm and encouraging. Tell them roughly how long this will take (~20 minutes for a first-time setup).
+
+Then check the current state of their setup:
+
+1. Read the `.env` file if it exists, or `.env.example` if not
+2. Check which environment variables are already filled in vs empty/placeholder
+3. Read `prisma/seed.ts` to see the current operating hours and capacity settings
+4. Check if the Prisma migrations have been run by looking for the `src/generated` directory or similar build artifacts
+
+Based on what you find, tell them:
+- What's already done
+- What still needs to be completed
+- Where you'll start
+
+Then proceed step by step through the checklist below. Complete each section fully before moving to the next. After each section, confirm with the user that it worked before continuing.
+
+---
+
+## Setup Checklist
+
+### Section 1: Node.js Check
+
+Run `node --version` to check if Node.js is installed.
+
+- If it's version 18 or higher: great, move on.
+- If it's lower than 18: tell them to download the latest LTS from nodejs.org and restart their terminal.
+- If the command fails: explain what Node.js is (the engine that runs this app) and walk them to nodejs.org to install it.
+
+### Section 2: Dependencies
+
+Check if `node_modules` exists. If not, run `npm install` and explain this downloads all the code libraries the app needs.
+
+### Section 3: Database (Neon)
+
+**Goal:** Get a PostgreSQL database URL into the `.env` file.
+
+Check if `DATABASE_URL` in `.env` still looks like the placeholder (`postgresql://user:password@host/dbname`).
+
+If it's still a placeholder:
+1. Explain what a database is (it's where all the reservation data lives — guest names, booking times, everything). Without it, nothing is saved.
+2. Tell them to go to neon.tech and sign up for a free account
+3. Walk them through: New Project → name it → Create project
+4. Tell them to find the "Connection string" on the project dashboard — it starts with `postgresql://`
+5. Ask them to paste it here in the chat so you can validate it looks correct (check it starts with `postgresql://` and contains `neon.tech`)
+6. Once confirmed, write it into their `.env` file using the Edit tool
+
+### Section 4: Portal Password
+
+**Goal:** Set a secure `PORTAL_ACCESS_CODE`.
+
+Check if it's still `"change-me"` or empty.
+
+If so:
+1. Explain this is the password they'll use every time they log into the owner dashboard
+2. Ask them to choose a password (suggest something memorable but not obvious — not their restaurant name alone)
+3. Write it into `.env`
+4. Remind them to save this password somewhere safe (a notes app, password manager, or written down)
+
+### Section 5: Security Keys
+
+**Goal:** Generate and set `JWT_SECRET` and `ENCRYPTION_KEY`.
+
+Check if these are still placeholders.
+
+For each one that needs to be set:
+1. Explain briefly what it does: JWT_SECRET signs login sessions so they can't be faked; ENCRYPTION_KEY protects sensitive data stored in the database
+2. Generate the value using Node.js:
+   - JWT_SECRET: `node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"`
+   - ENCRYPTION_KEY: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
+3. Write the generated value into `.env`
+4. Tell them: "You don't need to memorize these — they just need to be set once. But if you ever lose them, you'll need to regenerate them and re-deploy."
+
+### Section 6: Restaurant Defaults
+
+**Goal:** Customize `prisma/seed.ts` for their actual restaurant.
+
+Read the current values in `prisma/seed.ts`. Then ask the user the following questions (you can ask them all at once):
+
+1. **Operating hours:** "What days are you open, and what are your hours? For example: Monday–Thursday 11am–9pm, Friday–Saturday 11am–10pm, closed Sunday."
+2. **Seating duration:** "How long does a typical table stay for their meal? (e.g., 90 minutes)"
+3. **Reset buffer:** "After a table leaves, how many minutes do you need to clean and reset before the next guests sit down? (e.g., 15 minutes)"
+4. **Max guests:** "What's the maximum number of guests you can seat at the same time across all tables? (e.g., 40)"
+5. **Timezone:** "What city or timezone are you in? (e.g., New York, Chicago, Los Angeles, London)"
+
+Once you have their answers:
+- Update `prisma/seed.ts` with the correct `DEFAULT_OPERATING_HOURS`, `maxSeatingDuration`, `resetBuffer`, `maxTotalGuests`, and `timezone`
+- Show them what you changed and confirm it looks right
+
+Common timezone values to help them:
+- New York / East Coast → `America/New_York`
+- Chicago / Central → `America/Chicago`
+- Denver / Mountain → `America/Denver`
+- Los Angeles / West Coast → `America/Los_Angeles`
+- London → `Europe/London`
+- Paris / Central Europe → `Europe/Paris`
+- Sydney → `Australia/Sydney`
+- Toronto → `America/Toronto`
+
+### Section 7: Database Setup
+
+**Goal:** Run migrations and seed the database.
+
+Explain what's about to happen: "We're going to set up the tables in your database and load in your restaurant's settings."
+
+Run:
+```bash
+npx prisma migrate deploy
+```
+
+If this succeeds, run:
+```bash
+npx prisma db seed
+```
+
+If either command fails:
+- If the error mentions "can't reach database" or "connection refused": the DATABASE_URL is wrong. Walk them back to Section 3 to double-check it.
+- If the error mentions "SSL": make sure `?sslmode=require` is at the end of the DATABASE_URL
+- Show them the full error message and help them diagnose it
+
+### Section 8: Test Locally (Optional but Recommended)
+
+Ask: "Would you like to test the app on your computer before deploying it to the web?"
+
+If yes:
+1. Run `npm run dev`
+2. Tell them to open their browser and go to `http://localhost:3000`
+3. Walk them through what they should see: the public booking page
+4. Tell them to go to `http://localhost:3000/owner` and log in with their PORTAL_ACCESS_CODE
+5. If it works: "Great! Your app is working correctly."
+6. Press Ctrl+C to stop the local server when done
+
+### Section 9: Deploy to Vercel
+
+**Goal:** Get the app live on the internet.
+
+Ask if they've already deployed to Vercel. If not:
+
+1. Explain what Vercel is: "It's a free hosting service that will make your booking page accessible to anyone on the internet."
+2. They'll need to push their code to GitHub first. Check if they have a remote set up:
+   - Run `git remote -v`
+   - If nothing shows, help them push: explain they need to create a repo on github.com and connect it
+3. Walk them through Vercel:
+   - Go to vercel.com and sign in with GitHub
+   - Click "Add New > Project"
+   - Import their repository
+   - **Before deploying**, add all the environment variables from their `.env` file:
+     - `DATABASE_URL`
+     - `PORTAL_ACCESS_CODE`
+     - `JWT_SECRET`
+     - `ENCRYPTION_KEY`
+   - Click Deploy
+4. Once deployed, tell them their live URL (it'll be something like `yourrepo.vercel.app`)
+5. Test it: ask them to visit the URL and log into the owner portal
+
+### Section 10: Final Customization
+
+Tell them: "Your system is live! The last step is to set your restaurant's name, colors, and the text guests see when they book."
+
+Direct them to:
+1. Log into the owner portal at their live URL + `/owner`
+2. Go to Settings
+3. Set:
+   - Restaurant name
+   - Hero heading (e.g., "Reserve Your Table at [Restaurant Name].")
+   - Hero subtext (a short line that sets the mood)
+   - Color palette (5 options to choose from)
+   - Font pairing (4 options)
+
+---
+
+## Wrap Up
+
+Once all sections are complete:
+
+1. Summarize what was set up
+2. Remind them of their live URL and how to access the owner portal
+3. Tell them about Google Calendar (optional — they can set it up anytime from Settings)
+4. Let them know they can come back and type `/setup` anytime if they need help making changes
+
+---
+
+## Handling Questions
+
+If the user asks a question not directly in the checklist, answer it in plain language before returning to where you left off. Common questions:
+
+- **"What's a terminal / command prompt?"** — Explain it's a text-based way to run commands on their computer. On Mac: search "Terminal" in Spotlight. On Windows: search "Command Prompt" or "PowerShell".
+- **"I'm getting an error"** — Ask them to copy and paste the full error message. Read it carefully and diagnose the root cause before suggesting a fix.
+- **"Do I need to pay for any of this?"** — Neon and Vercel both have free tiers that are sufficient for most small restaurants. They'd only need paid plans if they get very high traffic.
+- **"Can I use a custom domain?"** — Yes. In Vercel project settings → Domains, they can add their own domain. They'd also need to update GOOGLE_REDIRECT_URI and the Google OAuth settings if they do this.
+- **"How do I update the app later?"** — Any changes pushed to their GitHub repo will automatically redeploy on Vercel.
+
+---
+
+## Tone Guidelines
+
+- Be encouraging. Setup can feel intimidating — reassure them they're doing great.
+- Never make them feel bad for not knowing something.
+- If something fails, treat it as a normal part of setup, not a mistake.
+- Use concrete examples (show don't just tell).
+- When giving instructions for external websites (Neon, Vercel, Google), be specific: "Click the button labeled X" not "navigate to the settings area."

--- a/README.md
+++ b/README.md
@@ -1,119 +1,321 @@
-# Reservations — Restaurant Reservation Template
+# Reservations — Open Source Restaurant Booking System
 
-A ready-to-fork reservation system for restaurants. Includes a public booking flow, owner portal (dashboard, calendar, guest management, analytics), and Google Calendar integration.
+A complete, self-hosted reservation system you can fork and make your own. Guests book through a clean public page; you manage everything from a private owner portal.
 
-Fork this repo, configure your restaurant's details, deploy, and you're live.
+**What's included:**
+- Public booking page with real-time availability
+- Owner portal: dashboard, calendar, guest profiles, analytics
+- Fully customizable branding (name, colors, fonts, logo)
+- Guest history and automatic duplicate merging
+- Optional Google Calendar sync for every reservation
 
-## Quick Start
+**Tech:** Next.js · PostgreSQL · Prisma · Tailwind · Vercel · Neon
 
-### 1. Fork & clone
+---
 
-Fork this repo on GitHub, then:
+## Who This Is For
 
+This is for restaurant owners who want full control over their reservation system — no monthly fees, no third-party platform. You'll need to be comfortable following technical instructions, or have someone set it up for you once.
+
+If you run into trouble at any step, see [Getting Help with AI](#getting-help-with-ai) — you can use a free AI assistant that will guide you through the entire setup interactively.
+
+---
+
+## What You'll Need
+
+Before starting, create free accounts at these services:
+
+| Service | What It's For | Sign Up |
+|---------|---------------|---------|
+| **GitHub** | Stores your code | [github.com](https://github.com) |
+| **Neon** | Hosts your database | [neon.tech](https://neon.tech) |
+| **Vercel** | Hosts your website | [vercel.com](https://vercel.com) |
+
+You'll also need **Node.js** installed on your computer (only needed once, for the initial database setup). Download it at [nodejs.org](https://nodejs.org) — choose the "LTS" version.
+
+**Optional:** A Google account if you want reservations to appear in Google Calendar.
+
+---
+
+## Setup Guide
+
+### Step 1 — Fork this repository
+
+"Forking" makes a personal copy of this project under your own GitHub account. You'll make all your changes there.
+
+1. Click **Fork** in the top-right corner of this GitHub page
+2. Choose your GitHub account as the destination
+3. Click **Create fork**
+
+You now have your own copy at `github.com/YOUR_USERNAME/reservations`.
+
+---
+
+### Step 2 — Create your database
+
+Your reservation data needs somewhere to live. Neon provides a free PostgreSQL database.
+
+1. Go to [neon.tech](https://neon.tech) and sign in
+2. Click **New Project**
+3. Give it a name (e.g., "my-restaurant") and click **Create project**
+4. On the project dashboard, find the **Connection string** — it looks like:
+   ```
+   postgresql://username:password@host.neon.tech/dbname?sslmode=require
+   ```
+5. Copy it — you'll need it in Step 4
+
+---
+
+### Step 3 — Deploy to Vercel
+
+Vercel hosts your website and makes it publicly accessible.
+
+1. Go to [vercel.com](https://vercel.com) and sign in with GitHub
+2. Click **Add New > Project**
+3. Find your forked `reservations` repository and click **Import**
+4. **Before clicking Deploy**, click **Environment Variables** and add each of the following:
+
+| Variable | Value | Notes |
+|----------|-------|-------|
+| `DATABASE_URL` | Your Neon connection string from Step 2 | |
+| `PORTAL_ACCESS_CODE` | A password you choose | This is how you log into the owner portal — pick something secure |
+| `JWT_SECRET` | A long random string | Use the generator below |
+| `ENCRYPTION_KEY` | A 64-character hex string | Use the generator below |
+
+**To generate `JWT_SECRET`:** Open Terminal (Mac) or Command Prompt (Windows) and run:
 ```bash
-git clone git@github.com:YOUR_USERNAME/reservations.git
-cd reservations
-npm install
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+```
+Copy the output and use it as your `JWT_SECRET`.
+
+**To generate `ENCRYPTION_KEY`:** Run:
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+Copy the 64-character output and use it as your `ENCRYPTION_KEY`.
+
+5. Click **Deploy**
+
+Vercel will build and deploy your site. This takes about a minute.
+
+---
+
+### Step 4 — Initialize your database
+
+After deployment, your database exists but is empty. You need to set it up once from your computer.
+
+1. Open Terminal (Mac) or Command Prompt (Windows)
+2. Clone your forked repo:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/reservations.git
+   cd reservations
+   ```
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+4. Create a `.env` file:
+   ```bash
+   cp .env.example .env
+   ```
+5. Open the `.env` file in any text editor (Notepad, TextEdit, VS Code) and fill in the same values you used in Vercel:
+   ```
+   DATABASE_URL="your-neon-connection-string"
+   PORTAL_ACCESS_CODE="your-chosen-password"
+   JWT_SECRET="your-generated-secret"
+   ENCRYPTION_KEY="your-generated-key"
+   ```
+6. Run the database migrations (creates all the tables):
+   ```bash
+   npx prisma migrate deploy
+   ```
+7. Seed the default settings:
+   ```bash
+   npx prisma db seed
+   ```
+
+Your database is now ready.
+
+---
+
+### Step 5 — Customize your restaurant defaults
+
+Before anything else, set your restaurant's basic operating hours and capacity in `prisma/seed.ts`. Open the file and edit the top section:
+
+```js
+const DEFAULT_OPERATING_HOURS = {
+  monday:    { open: true,  start: "11:00", end: "21:00" },
+  tuesday:   { open: true,  start: "11:00", end: "21:00" },
+  wednesday: { open: true,  start: "11:00", end: "21:00" },
+  thursday:  { open: true,  start: "11:00", end: "21:00" },
+  friday:    { open: true,  start: "11:00", end: "22:00" },
+  saturday:  { open: true,  start: "11:00", end: "22:00" },
+  sunday:    { open: false },
+};
 ```
 
-### 2. Configure environment
+Also update these values lower in the file:
+- `maxSeatingDuration: 90` — how long a party occupies a table (minutes)
+- `resetBuffer: 15` — turnover/cleaning time between seatings (minutes)
+- `maxTotalGuests: 20` — max simultaneous guests across all tables
+- `timezone: "America/New_York"` — your timezone ([list of valid values](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones))
 
+After editing, re-run the seed:
 ```bash
-cp .env.example .env
-```
-
-Fill in your values — see `.env.example` for documentation on each variable.
-
-### 3. Customize defaults
-
-Edit `prisma/seed.ts` to set your restaurant's:
-- Operating hours (days open, start/end times)
-- Seating duration and reset buffer
-- Max guest capacity
-- Timezone
-
-### 4. Set up the database
-
-```bash
-npx prisma migrate dev --name init
 npx prisma db seed
 ```
 
-### 5. Run the dev server
+---
 
-```bash
-npm run dev
-```
+### Step 6 — Configure your restaurant in the portal
 
-- Public booking page: `http://localhost:3000`
-- Owner portal: `http://localhost:3000/owner`
+Go to your Vercel deployment URL and log in at `/owner` with your `PORTAL_ACCESS_CODE`.
 
-### 6. Customize in the UI
+Navigate to **Settings** and configure:
 
-Once running, go to **Settings > Appearance** in the owner portal to set:
-- Restaurant name, hero heading, and subtext
-- Color palette and font pairing
-- Tab icon (emoji or image)
+- **Restaurant name** — appears on the booking page and confirmation
+- **Hero heading and subtext** — the text guests see when they land on your booking page
+- **Color palette** — choose from 5 preset themes
+- **Font pairing** — 4 options from classic serif to modern mono
+- **Logo** — upload an image or choose an emoji icon
+- **Operating hours** — fine-tune days and times (or reset to defaults)
+- **Booking window** — how many days ahead guests can book
 
 ---
 
-## Google Calendar Setup
+## Google Calendar Integration (Optional)
 
-The system uses Google OAuth 2.0 to create calendar events for each reservation.
+If you want a Google Calendar event created for every reservation:
 
 ### 1. Create a Google Cloud project
 
-1. Go to [Google Cloud Console](https://console.cloud.google.com)
-2. Create a new project (or use an existing one)
-3. Enable the **Google Calendar API** under APIs & Services > Library
+1. Go to [console.cloud.google.com](https://console.cloud.google.com)
+2. Click the project dropdown at the top → **New Project**
+3. Give it a name (e.g., "My Restaurant Reservations") and click **Create**
+4. Make sure your new project is selected in the dropdown
+5. Go to **APIs & Services > Library**
+6. Search for "Google Calendar API" and click **Enable**
 
-### 2. Configure the OAuth consent screen
+### 2. Configure the consent screen
 
-1. Go to APIs & Services > OAuth consent screen
-2. Choose **External** user type
-3. Fill in the app name, support email, and developer contact
-4. Add the scope: `https://www.googleapis.com/auth/calendar.events`
-5. Publish the app to **Production** status (click "Publish App") — this removes the 100-user cap and test-user requirement. Since the scope (`calendar.events`) is not sensitive/restricted, no Google verification is needed.
+1. Go to **APIs & Services > OAuth consent screen**
+2. Select **External** and click **Create**
+3. Fill in:
+   - App name: your restaurant name
+   - User support email: your email
+   - Developer contact: your email
+4. Click **Save and Continue**
+5. On the Scopes page, click **Add or Remove Scopes**
+6. Search for and add: `https://www.googleapis.com/auth/calendar.events`
+7. Click **Save and Continue** through the rest
+8. Back on the main OAuth screen, click **Publish App** → **Confirm**
+   > Publishing removes the 100-user test limit. The `calendar.events` scope doesn't require Google verification.
 
 ### 3. Create OAuth credentials
 
-1. Go to APIs & Services > Credentials
+1. Go to **APIs & Services > Credentials**
 2. Click **Create Credentials > OAuth client ID**
 3. Application type: **Web application**
 4. Add **Authorized JavaScript origins**:
-   - `http://localhost:3000` (development)
-   - `https://yourdomain.com` (production)
+   - `https://your-vercel-domain.vercel.app`
 5. Add **Authorized redirect URIs**:
-   - `http://localhost:3000/api/auth/google/callback` (development)
-   - `https://yourdomain.com/api/auth/google/callback` (production)
-6. Copy the Client ID and Client Secret into your `.env`
+   - `https://your-vercel-domain.vercel.app/api/auth/google/callback`
+6. Click **Create**
+7. Copy the **Client ID** and **Client Secret**
 
-### 4. Connect from the app
+### 4. Add credentials to Vercel
 
-1. Log into the owner portal at `/owner`
-2. Go to **Settings > Google Calendar**
-3. Click **Connect Google Calendar** and complete the OAuth flow
+In your Vercel project settings → Environment Variables, add:
+
+| Variable | Value |
+|----------|-------|
+| `GOOGLE_CLIENT_ID` | Your Client ID |
+| `GOOGLE_CLIENT_SECRET` | Your Client Secret |
+| `GOOGLE_REDIRECT_URI` | `https://your-vercel-domain.vercel.app/api/auth/google/callback` |
+
+Redeploy your Vercel project after adding these (Deployments → Redeploy).
+
+### 5. Connect from the app
+
+1. Log into the owner portal → **Settings**
+2. Scroll to **Google Calendar**
+3. Click **Connect Google Calendar** and complete the sign-in
 
 ---
 
-## Deployment
+## Running Locally (Optional)
 
-### Vercel + Neon
+If you want to test changes before deploying:
 
-1. Push the repo to GitHub
-2. Import into [Vercel](https://vercel.com)
-3. Set all environment variables in Vercel project settings
-4. Create a [Neon](https://neon.tech) Postgres database and set `DATABASE_URL`
-5. Update `GOOGLE_REDIRECT_URI` to your production callback URL
-6. Add your production domain to the Google OAuth authorized origins and redirect URIs
+```bash
+# Start the local development server
+npm run dev
+```
+
+- Booking page: [http://localhost:3000](http://localhost:3000)
+- Owner portal: [http://localhost:3000/owner](http://localhost:3000/owner)
 
 ---
 
-## Tech Stack
+## Getting Help with AI
 
-- **Framework:** Next.js 16 (App Router)
-- **Database:** PostgreSQL (Neon) + Prisma ORM
-- **Styling:** Tailwind CSS 4
-- **Auth:** Passcode + JWT
-- **Calendar:** Google Calendar API (OAuth 2.0)
-- **Hosting:** Vercel
+This repo includes a guided setup assistant you can use if you have [Claude Code](https://claude.ai/code) installed.
+
+**What is Claude Code?** It's a free AI assistant that runs in your terminal and can walk you through technical tasks step by step, answer questions in plain language, and even run commands for you.
+
+### Install Claude Code
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+Then sign in:
+```bash
+claude
+```
+
+### Use the Setup Wizard
+
+Once inside your project directory, type:
+
+```
+/setup
+```
+
+The assistant will check what's already configured, ask you questions about your restaurant, and guide you through every remaining step — including generating secrets, walking you through Neon and Vercel, and verifying your database is working.
+
+You can also just ask it questions in plain English:
+- *"I'm stuck on the database step, what do I do?"*
+- *"How do I find my Neon connection string?"*
+- *"My site deployed but I can't log in — what's wrong?"*
+
+---
+
+## Troubleshooting
+
+**"I can't log into the owner portal"**
+Double-check that `PORTAL_ACCESS_CODE` in your Vercel environment variables matches exactly what you're typing. It's case-sensitive.
+
+**"The database migration failed"**
+Make sure your `DATABASE_URL` in `.env` is the correct Neon connection string, including `?sslmode=require` at the end.
+
+**"The booking page shows no available times"**
+Log into the owner portal → Settings → check that your operating hours are configured and at least one day is set to open.
+
+**"Google Calendar connect fails"**
+Make sure `GOOGLE_REDIRECT_URI` in Vercel matches exactly the redirect URI you added in Google Cloud (including `https://`, your full domain, and `/api/auth/google/callback`).
+
+**"I changed settings in `seed.ts` but nothing changed"**
+You need to re-run `npx prisma db seed` after editing the file.
+
+---
+
+## Contributing
+
+Pull requests are welcome. For significant changes, open an issue first to discuss what you'd like to change.
+
+---
+
+## License
+
+MIT

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -331,17 +331,30 @@ export default function BookingPage() {
             02 &mdash; Choose Your Time
           </p>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-            {selectedDaySlots.filter((slot) => !slot.isFull).map((slot) => {
+            {selectedDaySlots.map((slot) => {
               const timeObj = parse(slot.time, "HH:mm", new Date());
+              const remaining = slot.maxCapacity - slot.currentGuests;
+              const isLimited = !slot.isFull && remaining <= 3;
               return (
                 <SelectionCard
                   key={slot.time}
                   selected={selectedTime === slot.time}
+                  disabled={slot.isFull}
                   onClick={() => handleTimeSelect(slot.time)}
                 >
                   <span className="font-mono text-xs tracking-[0.5px]">
                     {format(timeObj, "h:mm a")}
                   </span>
+                  {slot.isFull && (
+                    <span className="block font-mono text-[9px] uppercase tracking-[1px] mt-0.5">
+                      Full
+                    </span>
+                  )}
+                  {isLimited && (
+                    <span className="block font-mono text-[9px] uppercase tracking-[1px] mt-0.5 text-muted">
+                      {remaining} {remaining === 1 ? "spot" : "spots"} left
+                    </span>
+                  )}
                 </SelectionCard>
               );
             })}

--- a/src/app/owner/settings/page.tsx
+++ b/src/app/owner/settings/page.tsx
@@ -9,6 +9,7 @@ import {
   Coffee,
   Croissant,
   UtensilsCrossed,
+  X,
 } from "lucide-react";
 import {
   PALETTES,
@@ -110,6 +111,7 @@ export default function SettingsPage() {
   const savedSettingsRef = useRef<string>("");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [showResetDialog, setShowResetDialog] = useState(false);
 
   const isDirty = useCallback(() => {
     if (!settings || !savedSettingsRef.current) return false;
@@ -214,6 +216,30 @@ export default function SettingsPage() {
     }
   }
 
+  function handleReset() {
+    if (!settings) return;
+    setSettings({
+      ...settings,
+      operatingHours: {
+        monday: { open: true, start: "11:00", end: "21:00" },
+        tuesday: { open: true, start: "11:00", end: "21:00" },
+        wednesday: { open: true, start: "11:00", end: "21:00" },
+        thursday: { open: true, start: "11:00", end: "21:00" },
+        friday: { open: true, start: "11:00", end: "22:00" },
+        saturday: { open: true, start: "11:00", end: "22:00" },
+        sunday: { open: false, start: "11:00", end: "21:00" },
+      },
+      maxSeatingDuration: 90,
+      resetBuffer: 15,
+      slotInterval: 15,
+      bookingWindowDays: 30,
+      maxTotalGuests: 20,
+      colorPalette: "classic",
+      fontPairing: "serif-mono",
+    });
+    setShowResetDialog(false);
+  }
+
   function updateDay(day: string, field: string, value: boolean | string) {
     if (!settings) return;
     setSettings({
@@ -282,6 +308,13 @@ export default function SettingsPage() {
               Saved
             </span>
           )}
+          <button
+            type="button"
+            onClick={() => setShowResetDialog(true)}
+            className="font-mono text-[11px] uppercase tracking-[2px] border border-[#E0E0E0] bg-white text-[#0D0D0D] px-4 py-2.5 rounded-none cursor-pointer hover:bg-[#F5F5F5] transition-colors"
+          >
+            Reset
+          </button>
           <Button
             className="!w-auto !px-5 flex items-center gap-2"
             onClick={handleSave}
@@ -909,6 +942,51 @@ export default function SettingsPage() {
         )}
       </section>
         </>
+      )}
+
+      {/* Reset to Defaults Confirmation Dialog */}
+      {showResetDialog && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center"
+          onClick={() => setShowResetDialog(false)}
+        >
+          <div className="absolute inset-0 bg-black/20" />
+          <div
+            className="relative bg-white border border-[#E0E0E0] rounded-none shadow-lg max-w-[420px] w-full mx-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between p-6 pb-4">
+              <h3 className="font-mono text-sm font-bold uppercase tracking-[2px]">
+                Reset to Defaults
+              </h3>
+              <button
+                onClick={() => setShowResetDialog(false)}
+                className="cursor-pointer hover:opacity-60"
+              >
+                <X size={18} strokeWidth={1.5} />
+              </button>
+            </div>
+            <div className="px-6 pb-6">
+              <p className="font-serif text-sm mb-5">
+                Reset all settings to defaults? Your current configuration will be lost.
+              </p>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setShowResetDialog(false)}
+                  className="flex-1 font-mono text-[11px] uppercase tracking-[2px] border border-[#E0E0E0] bg-white text-[#0D0D0D] px-5 py-3 rounded-none cursor-pointer hover:bg-[#F5F5F5] transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleReset}
+                  className="flex-1 font-mono text-[11px] uppercase tracking-[2px] bg-[#C45C4A] text-white border-none px-5 py-3 rounded-none cursor-pointer hover:bg-[#b04f3f] transition-colors"
+                >
+                  Reset
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- **Fix #19** — Show availability status on booking time slots: full slots now display as greyed-out/disabled with a "Full" label; slots with ≤3 spots remaining show "X spots left"
- **Fix #23** — Add Reset to Defaults button in Settings: confirms before restoring operating hours, timing, capacity, and theme to seed defaults
- **README rewrite** — Full beginner-friendly setup guide covering Neon, Vercel, Google Calendar, and troubleshooting for non-technical restaurant owners
- **`/setup` agent** — Adds `.claude/commands/setup.md`, a Claude Code slash command that acts as an interactive setup wizard: checks current config state, asks plain-language questions about the restaurant, generates secrets, walks through each external service step by step

## Test plan

- [ ] On the public booking page, select a date and verify full slots appear greyed out with "Full", and near-capacity slots show "X spots left"
- [ ] In Settings, click Reset and confirm the dialog appears; confirm cancelling does nothing and confirming resets the fields
- [ ] Verify README renders correctly on GitHub with all steps and links intact
- [ ] In a fresh clone with Claude Code installed, run `/setup` and confirm the wizard starts and reads the current `.env` state

https://claude.ai/code/session_01WPjhEvCoXeWTEuP2fAvVBA